### PR TITLE
feat: Add cross-platform CI support (#40)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,22 +7,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:13
-        env:
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test
-          POSTGRES_DB: test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -34,8 +22,10 @@ jobs:
 
     - name: Install Poetry
       run: |
-        curl -sSL https://install.python-poetry.org | python3 -
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        python -m pip install --upgrade pip
+        python -m pip install pipx
+        python -m pipx ensurepath
+        pipx install poetry
 
     - name: Install dependencies
       run: poetry install
@@ -50,9 +40,3 @@ jobs:
 
     - name: Run tests
       run: poetry run pytest
-      env:
-        POSTGRES_USER: test
-        POSTGRES_PASSWORD: test
-        POSTGRES_DB: test
-        POSTGRES_HOST: localhost
-        POSTGRES_PORT: 5432


### PR DESCRIPTION
Modified the GitHub Actions CI workflow to run on Windows, macOS, and Ubuntu.

- Used a matrix strategy to run tests on `windows-latest`, `macos-latest`, and `ubuntu-latest`.
- Removed the hardcoded PostgreSQL service, as the integration tests use `testcontainers` to spin up their own database instance. This requires a Docker daemon to be present in the runner environment.
- Updated the Poetry installation method to a cross-platform one using `pipx`.