### PR TITLE
fix(ci): remove step-security/ghaction-setup-docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,6 @@ jobs:
           python -m pipx ensurepath
           pipx install poetry
 
-      - name: Set up Docker
-        uses: step-security/ghaction-setup-docker@v4
-        with:
-          daemon-config: |
-            {
-              "hosts": ["tcp://127.0.0.1:2375"]
-            }
-
       - name: Install dependencies
         run: poetry install
 


### PR DESCRIPTION
The step-security/ghaction-setup-docker action was causing the workflow to fail due to a subscription issue. This change removes the action, as GitHub-hosted runners have Docker pre-installed and this step is not necessary.