### PR TITLE
fix: Correct testcontainer lifecycle management

### DIFF
--- a/tests/integration/test_postgres_loader.py
+++ b/tests/integration/test_postgres_loader.py
@@ -35,8 +35,10 @@ SAMPLE_DRUG_DATA = """primaryid$caseid$drug_seq$drugname
 @pytest.fixture(scope="module")
 def postgres_container() -> Iterator[PostgresContainer]:
     """Fixture to start and stop a PostgreSQL container for the test module."""
-    with PostgresContainer("postgres:13") as container:
-        yield container
+    container = PostgresContainer("postgres:13")
+    container.start()
+    yield container
+    container.stop()
 
 
 @pytest.fixture


### PR DESCRIPTION
The GitHub workflow was failing with an `AttributeError: 'PostgresContainer' object has no attribute '_container'` in the `__del__` method of the `DockerContainer`. This was caused by an issue with the cleanup of the `PostgresContainer` when using a `with` statement in the pytest fixture.

This change modifies the `postgres_container` fixture in `tests/integration/test_postgres_loader.py` to manually start and stop the container using `start()` and `stop()`. This more explicit lifecycle management resolves the error during garbage collection.