### PR TITLE
Fix failing postgres tests by upgrading testcontainers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -316,21 +316,6 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
-name = "deprecation"
-version = "2.1.0"
-description = "A library to handle automated deprecations"
-optional = false
-python-versions = "*"
-groups = ["dev"]
-files = [
-    {file = "deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a"},
-    {file = "deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff"},
-]
-
-[package.dependencies]
-packaging = "*"
-
-[[package]]
 name = "docker"
 version = "7.1.0"
 description = "A Python library for the Docker Engine API."
@@ -1455,7 +1440,7 @@ version = "1.1.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc"},
     {file = "python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab"},
@@ -1773,37 +1758,58 @@ sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
 name = "testcontainers"
-version = "3.7.1"
-description = "Library provides lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container"
+version = "4.13.0"
+description = "Python library for throwaway instances of anything that can run in a Docker container"
 optional = false
-python-versions = ">=3.7"
+python-versions = "<4.0,>=3.9"
 groups = ["dev"]
 files = [
-    {file = "testcontainers-3.7.1-py2.py3-none-any.whl", hash = "sha256:7f48cef4bf0ccd78f1a4534d4b701a003a3bace851f24eae58a32f9e3f0aeba0"},
+    {file = "testcontainers-4.13.0-py3-none-any.whl", hash = "sha256:784292e0a3f3a4588fbbf5d6649adda81fea5fd61ad3dc73f50a7a903904aade"},
+    {file = "testcontainers-4.13.0.tar.gz", hash = "sha256:ee2bc39324eeeeb710be779208ae070c8373fa9058861859203f536844b0f412"},
 ]
 
 [package.dependencies]
-deprecation = "*"
-docker = ">=4.0.0"
+docker = "*"
+python-dotenv = "*"
+typing-extensions = "*"
+urllib3 = "*"
 wrapt = "*"
 
 [package.extras]
-arangodb = ["python-arango"]
-azurite = ["azure-storage-blob"]
+arangodb = ["python-arango (>=7.8,<8.0)"]
+aws = ["boto3", "httpx"]
+azurite = ["azure-storage-blob (>=12.19,<13.0)"]
+chroma = ["chromadb-client (>=1.0.0,<2.0.0)"]
 clickhouse = ["clickhouse-driver"]
-docker-compose = ["docker-compose"]
-google-cloud-pubsub = ["google-cloud-pubsub (<2)"]
-kafka = ["kafka-python"]
+cosmosdb = ["azure-cosmos"]
+db2 = ["ibm_db_sa ; platform_machine != \"aarch64\" and platform_machine != \"arm64\"", "sqlalchemy"]
+generic = ["httpx", "redis"]
+google = ["google-cloud-datastore (>=2)", "google-cloud-pubsub (>=2)"]
+influxdb = ["influxdb", "influxdb-client"]
+k3s = ["kubernetes", "pyyaml"]
 keycloak = ["python-keycloak"]
-mongo = ["pymongo"]
-mssqlserver = ["pymssql"]
-mysql = ["pymysql", "sqlalchemy"]
+localstack = ["boto3"]
+mailpit = ["cryptography"]
+minio = ["minio"]
+mongodb = ["pymongo"]
+mssql = ["pymssql ; platform_machine != \"arm64\" or python_version >= \"3.10\"", "sqlalchemy"]
+mysql = ["pymysql[rsa]", "sqlalchemy"]
+nats = ["nats-py"]
 neo4j = ["neo4j"]
-oracle = ["cx-Oracle", "sqlalchemy"]
-postgresql = ["psycopg2-binary", "sqlalchemy"]
+openfga = ["openfga-sdk ; python_version >= \"3.10\""]
+opensearch = ["opensearch-py"]
+oracle = ["oracledb", "sqlalchemy"]
+oracle-free = ["oracledb", "sqlalchemy"]
+qdrant = ["qdrant-client"]
 rabbitmq = ["pika"]
 redis = ["redis"]
+registry = ["bcrypt"]
+scylla = ["cassandra-driver (==3.29.1)"]
 selenium = ["selenium"]
+sftp = ["cryptography"]
+test-module-import = ["httpx"]
+trino = ["trino"]
+weaviate = ["weaviate-client (>=4.5.4,<5.0.0)"]
 
 [[package]]
 name = "tomli"
@@ -2088,4 +2094,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "28ca161738cd3016b68d66990f02966ada565b5df2d8f1044391bafbe19aae25"
+content-hash = "83f6838586232e24374361ae64fa7db7fff723eae3a0433303df176449914720"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ black = "^23.9"
 ruff = "^0.0.292"
 mypy = "^1.5"
 pytest-mock = "^3.12"
-testcontainers = {version = "^3.7", extras = ["postgres"]}
+testcontainers = {version = "^4.4.0", extras = ["postgres"]}
 sqlalchemy = "^2.0"
 psycopg2-binary = "^2.9.9"
 pytest-cov = "^7.0.0"

--- a/tests/integration/test_checksum_feature.py
+++ b/tests/integration/test_checksum_feature.py
@@ -35,9 +35,9 @@ def db_settings(postgres_container: PostgresContainer) -> DatabaseSettings:
         type="postgresql",
         host=postgres_container.get_container_host_ip(),
         port=postgres_container.get_exposed_port(5432),
-        user=postgres_container.POSTGRES_USER,
-        password=postgres_container.POSTGRES_PASSWORD,
-        dbname=postgres_container.POSTGRES_DB,
+        user=postgres_container.username,
+        password=postgres_container.password,
+        dbname=postgres_container.dbname,
     )
 
 

--- a/tests/integration/test_delta_load_engine.py
+++ b/tests/integration/test_delta_load_engine.py
@@ -31,9 +31,9 @@ def db_settings(postgres_container: PostgresContainer) -> DatabaseSettings:
         type="postgresql",
         host=postgres_container.get_container_host_ip(),
         port=postgres_container.get_exposed_port(5432),
-        user=postgres_container.POSTGRES_USER,
-        password=postgres_container.POSTGRES_PASSWORD,
-        dbname=postgres_container.POSTGRES_DB,
+        user=postgres_container.username,
+        password=postgres_container.password,
+        dbname=postgres_container.dbname,
     )
 
 

--- a/tests/integration/test_parquet_staging_load.py
+++ b/tests/integration/test_parquet_staging_load.py
@@ -31,9 +31,9 @@ def db_settings(postgres_container: PostgresContainer) -> DatabaseSettings:
         type="postgresql",
         host=postgres_container.get_container_host_ip(),
         port=postgres_container.get_exposed_port(5432),
-        user=postgres_container.POSTGRES_USER,
-        password=postgres_container.POSTGRES_PASSWORD,
-        dbname=postgres_container.POSTGRES_DB,
+        user=postgres_container.username,
+        password=postgres_container.password,
+        dbname=postgres_container.dbname,
     )
 
 

--- a/tests/integration/test_postgres_loader.py
+++ b/tests/integration/test_postgres_loader.py
@@ -35,10 +35,8 @@ SAMPLE_DRUG_DATA = """primaryid$caseid$drug_seq$drugname
 @pytest.fixture(scope="module")
 def postgres_container() -> Iterator[PostgresContainer]:
     """Fixture to start and stop a PostgreSQL container for the test module."""
-    container = PostgresContainer("postgres:13")
-    container.start()
-    yield container
-    container.stop()
+    with PostgresContainer("postgres:13") as container:
+        yield container
 
 
 @pytest.fixture

--- a/tests/integration/test_xml_load_engine.py
+++ b/tests/integration/test_xml_load_engine.py
@@ -30,9 +30,9 @@ def db_settings(postgres_container: PostgresContainer) -> DatabaseSettings:
         type="postgresql",
         host=postgres_container.get_container_host_ip(),
         port=postgres_container.get_exposed_port(5432),
-        user=postgres_container.POSTGRES_USER,
-        password=postgres_container.POSTGRES_PASSWORD,
-        dbname=postgres_container.POSTGRES_DB,
+        user=postgres_container.username,
+        password=postgres_container.password,
+        dbname=postgres_container.dbname,
     )
 
 


### PR DESCRIPTION
The GitHub Actions tests were failing with an `AttributeError: 'PostgresContainer' object has no attribute '_container'`. This was due to an old version of `testcontainers` being used.

This commit a new `testcontainers` version and updates the test code to use the new API.

Specifically, this commit:
- Upgrades `testcontainers` to `^4.4.0` in `pyproject.toml`.
- Updates the test files to use the new `testcontainers` API for accessing container credentials (e.g., `username` instead of `POSTGRES_USER`).
- Updates the `PostgresContainer` fixture to use a `with` statement for better resource management.