### PR TITLE
fix(ci): Downgrade runner OS to fix Docker setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         python-version: ['3.11']
     services:
       postgres:


### PR DESCRIPTION
The CI build was failing on the "Set up Docker" step. The logs indicated an incompatibility between the `docker-practice/actions-setup-docker@v1` action and the `ubuntu-latest` runner, which has been updated to Ubuntu 24.04.

This change downgrades the runner OS to `ubuntu-22.04` to resolve the Docker setup issue and restore the CI pipeline to a working state.