### PR TITLE
fix(ci): Allow docker downgrade in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker
-        uses: docker-practice/actions-setup-docker@v1
+        run: |
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+            $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt-get -y --allow-downgrades install docker-ce=5:20.10.24~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:20.10.24~3-0~ubuntu-$(lsb_release -cs) containerd.io
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
The github actions workflow was failing with the error: `E: Packages were downgraded and -y was used without --allow-downgrades.`

This was caused by the `docker-practice/actions-setup-docker@v1` action not allowing downgrades.

This commit replaces the action with a manual installation of docker that includes the `--allow-downgrades` flag.