### PR TITLE
Fix(tests): Add workaround for testcontainers on Windows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+
+if sys.platform == "win32":
+    # Workaround for testcontainers on Windows
+    # See: https://github.com/testcontainers/testcontainers-python/issues/141
+    from testcontainers.core.docker_client import DockerClient
+
+    DockerClient(host="npipe:////./pipe/docker_engine")


### PR DESCRIPTION
The integration tests were failing on Windows due to an issue with how testcontainers-python detects the Docker host. This change adds a workaround to `tests/conftest.py` that explicitly configures the Docker client when the tests are run on a Windows platform.

This is a known issue with `testcontainers-python`, and this fix implements the recommended solution.